### PR TITLE
feat: add Helm chart for jx-app-sd-exporter

### DIFF
--- a/jx-app-sd-exporter/.helmignore
+++ b/jx-app-sd-exporter/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/jx-app-sd-exporter/Chart.yaml
+++ b/jx-app-sd-exporter/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Stackdriver Exporter App for Jenkins X
+name: jx-app-sd-exporter
+version: 0.1.0-SNAPSHOT

--- a/jx-app-sd-exporter/README.md
+++ b/jx-app-sd-exporter/README.md
@@ -1,0 +1,7 @@
+# jx-app-sd-exporter
+
+The chart for the Stackdriver Exporter application for Jenkins X.
+
+## What's in the chart?
+
+This chart contains all the resources necessary to deploy a customize version of fluentd-gcp and prometheus-to-sd containers, adding the ability to override the target GCP project to send to logs/metrics to.

--- a/jx-app-sd-exporter/templates/_helpers.tpl
+++ b/jx-app-sd-exporter/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/jx-app-sd-exporter/templates/app.yaml
+++ b/jx-app-sd-exporter/templates/app.yaml
@@ -1,0 +1,6 @@
+apiVersion: jenkins.io/v1
+kind: App
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/jx-app-sd-exporter/templates/fluentd-gcp-configmap.yaml
+++ b/jx-app-sd-exporter/templates/fluentd-gcp-configmap.yaml
@@ -1,0 +1,571 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: fluentd-gcp-config
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+data:
+  containers.input.conf: |-
+    # This configuration file for Fluentd is used
+    # to watch changes to Docker log files that live in the
+    # directory /var/lib/docker/containers/ and are symbolically
+    # linked to from the /var/log/containers directory using names that capture the
+    # pod name and container name. These logs are then submitted to
+    # Google Cloud Logging which assumes the installation of the cloud-logging plug-in.
+    #
+    # Example
+    # =======
+    # A line in the Docker log file might look like this JSON:
+    #
+    # {"log":"2014/09/25 21:15:03 Got request with path wombat\\n",
+    #  "stream":"stderr",
+    #   "time":"2014-09-25T21:15:03.499185026Z"}
+    #
+    # The original tag is derived from the log file's location.
+    # For example a Docker container's logs might be in the directory:
+    #  /var/lib/docker/containers/997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b
+    # and in the file:
+    #  997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b-json.log
+    # where 997599971ee6... is the Docker ID of the running container.
+    # The Kubernetes kubelet makes a symbolic link to this file on the host
+    # machine in the /var/log/containers directory which includes the pod name,
+    # the namespace name and the Kubernetes container name:
+    #    synthetic-logger-0.25lps-pod_default_synth-lgr-997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b.log
+    #    ->
+    #    /var/lib/docker/containers/997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b/997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b-json.log
+    # The /var/log directory on the host is mapped to the /var/log directory in the container
+    # running this instance of Fluentd and we end up collecting the file:
+    #   /var/log/containers/synthetic-logger-0.25lps-pod_default_synth-lgr-997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b.log
+    # This results in the tag:
+    #  var.log.containers.synthetic-logger-0.25lps-pod_default_synth-lgr-997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b.log
+    # where 'synthetic-logger-0.25lps-pod' is the pod name, 'default' is the
+    # namespace name, 'synth-lgr' is the container name and '997599971ee6..' is
+    # the container ID.
+    # The record reformer is used to extract pod_name, namespace_name and
+    # container_name from the tag and set them in a local_resource_id in the
+    # format of:
+    # 'k8s_container.<NAMESPACE_NAME>.<POD_NAME>.<CONTAINER_NAME>'.
+    # The reformer also changes the tags to 'stderr' or 'stdout' based on the
+    # value of 'stream'.
+    # local_resource_id is later used by google_cloud plugin to determine the
+    # monitored resource to ingest logs against.
+
+    # Json Log Example:
+    # {"log":"[info:2016-02-16T16:04:05.930-08:00] Some log text here\n","stream":"stdout","time":"2016-02-17T00:04:05.931087621Z"}
+    # CRI Log Example:
+    # 2016-02-17T00:04:05.931087621Z stdout F [info:2016-02-16T16:04:05.930-08:00] Some log text here
+    <source>
+      @type tail
+
+      path /var/log/containers/*.log
+
+
+      pos_file /var/run/google-fluentd/pos-files/gcp-containers.pos
+
+      # Tags at this point are in the format of:
+      # reform.var.log.containers.<POD_NAME>_<NAMESPACE_NAME>_<CONTAINER_NAME>-<CONTAINER_ID>.log
+      tag reform.*
+      read_from_head true
+      <parse>
+        @type multi_format
+        <pattern>
+          format json
+          time_key time
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
+          time_format %Y-%m-%dT%H:%M:%S.%N%:z
+        </pattern>
+      </parse>
+    </source>
+
+    <filter reform.**>
+      @type parser
+      format /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<log>.*)/
+      reserve_data true
+      suppress_parse_error_log true
+      emit_invalid_record_to_error false
+      key_name log
+    </filter>
+
+
+    <filter reform.**>
+      # This plugin uses environment variables KUBERNETES_SERVICE_HOST and
+      # KUBERNETES_SERVICE_PORT to talk to the API server. These environment
+      # variables are added by kubelet automatically.
+      @type kubernetes_metadata
+      # Interval in seconds to dump cache stats locally in the Fluentd log.
+      stats_interval 300
+      # TTL in seconds of each cached element.
+      cache_ttl 30
+
+      # Skip fetching unused metadata.
+      skip_container_metadata true
+      skip_master_url true
+      skip_namespace_metadata true
+
+    </filter>
+
+    <filter reform.**>
+      # We have to use record_modifier because only this plugin supports complex
+      # logic to modify record the way we need.
+      @type record_modifier
+      enable_ruby true
+      <record>
+        # Extract "kubernetes"->"labels" and set them as
+        # "logging.googleapis.com/labels". Prefix these labels with
+        # "k8s-pod" to distinguish with other labels and avoid
+        # label name collision with other types of labels.
+        _dummy_ ${if record.is_a?(Hash) && record.has_key?('kubernetes') && record['kubernetes'].has_key?('labels') && record['kubernetes']['labels'].is_a?(Hash); then; record["logging.googleapis.com/labels"] = record['kubernetes']['labels'].map{ |k, v| ["k8s-pod/#{k}", v]}.to_h; end; nil}
+      </record>
+      # Delete this dummy field and the rest of "kubernetes" and "docker".
+      remove_keys _dummy_,kubernetes,docker
+    </filter>
+
+
+    <match reform.**>
+      @type record_reformer
+      enable_ruby true
+      <record>
+        # Extract local_resource_id from tag for 'k8s_container' monitored
+        # resource. The format is:
+        # 'k8s_container.<namespace_name>.<pod_name>.<container_name>'.
+        "logging.googleapis.com/local_resource_id" ${"k8s_container.#{tag_suffix[4].rpartition('.')[0].split('_')[1]}.#{tag_suffix[4].rpartition('.')[0].split('_')[0]}.#{tag_suffix[4].rpartition('.')[0].split('_')[2].rpartition('-')[0]}"}
+        # Rename the field 'log' to a more generic field 'message'. This way the
+        # fluent-plugin-google-cloud knows to flatten the field as textPayload
+        # instead of jsonPayload after extracting 'time', 'severity' and
+        # 'stream' from the record.
+        message ${record['log']}
+        # If 'severity' is not set, assume stderr is ERROR and stdout is INFO.
+        severity ${record['severity'] || if record['stream'] == 'stderr' then 'ERROR' else 'INFO' end}
+      </record>
+      tag ${if record['stream'] == 'stderr' then 'raw.stderr' else 'raw.stdout' end}
+      remove_keys stream,log
+    </match>
+
+    # Detect exceptions in the log output and forward them as one log entry.
+    <match {raw.stderr,raw.stdout}>
+      @type detect_exceptions
+
+      remove_tag_prefix raw
+      message message
+      stream "logging.googleapis.com/local_resource_id"
+      multiline_flush_interval 5
+      max_bytes 500000
+      max_lines 1000
+    </match>
+  monitoring.conf: |-
+    # This source is used to acquire approximate process start timestamp,
+    # which purpose is explained before the corresponding output plugin.
+    <source>
+      @type exec
+      command /bin/sh -c 'date +%s'
+      tag process_start
+      time_format %Y-%m-%d %H:%M:%S
+      keys process_start_timestamp
+    </source>
+
+    # This filter is used to convert process start timestamp to integer
+    # value for correct ingestion in the prometheus output plugin.
+    <filter process_start>
+      @type record_transformer
+      enable_ruby true
+      auto_typecast true
+      <record>
+        process_start_timestamp ${record["process_start_timestamp"].to_i}
+      </record>
+    </filter>
+  output.conf: |-
+    # This match is placed before the all-matching output to provide metric
+    # exporter with a process start timestamp for correct exporting of
+    # cumulative metrics to Stackdriver.
+    <match process_start>
+      @type prometheus
+
+      <metric>
+        type gauge
+        name process_start_time_seconds
+        desc Timestamp of the process start in seconds
+        key process_start_timestamp
+      </metric>
+    </match>
+
+    # This filter allows to count the number of log entries read by fluentd
+    # before they are processed by the output plugin. This in turn allows to
+    # monitor the number of log entries that were read but never sent, e.g.
+    # because of liveness probe removing buffer.
+    <filter **>
+      @type prometheus
+      <metric>
+        type counter
+        name logging_entry_count
+        desc Total number of log entries generated by either application containers or system components
+      </metric>
+    </filter>
+
+    # This section is exclusive for k8s_container logs. Those come with
+    # 'stderr'/'stdout' tags.
+    # TODO(instrumentation): Reconsider this workaround later.
+    # Trim the entries which exceed slightly less than 100KB, to avoid
+    # dropping them. It is a necessity, because Stackdriver only supports
+    # entries that are up to 100KB in size.
+    <filter {stderr,stdout}>
+      @type record_transformer
+      enable_ruby true
+      <record>
+        message ${record['message'].length > 100000 ? "[Trimmed]#{record['message'][0..100000]}..." : record['message']}
+      </record>
+    </filter>
+
+    # Do not collect fluentd's own logs to avoid infinite loops.
+    <match fluent.**>
+      @type null
+    </match>
+
+    # Add a unique insertId to each log entry that doesn't already have it.
+    # This helps guarantee the order and prevent log duplication.
+    <filter **>
+      @type add_insert_ids
+    </filter>
+
+    # This filter parses the 'source' field created for glog lines into a single
+    # top-level field, for proper processing by the output plugin.
+    # For example, if a record includes:
+    #     {"source":"handlers.go:131"},
+    # then the following entry will be added to the record:
+    #     {"logging.googleapis.com/sourceLocation":
+    #          {"file":"handlers.go", "line":"131"}
+    #     }
+    <filter **>
+      @type record_transformer
+      enable_ruby true
+      <record>
+        "logging.googleapis.com/sourceLocation" ${if record.is_a?(Hash) && record.has_key?('source'); source_parts = record['source'].split(':', 2); {'file' => source_parts[0], 'line' => source_parts[1]} if source_parts.length == 2; else; nil; end}
+      </record>
+    </filter>
+
+
+    # This section is exclusive for k8s_container logs. These logs come with
+    # 'stderr'/'stdout' tags.
+    # We use a separate output stanza for 'k8s_node' logs with a smaller buffer
+    # because node logs are less important than user's container logs.
+    <match {stderr,stdout}>
+      @type google_cloud
+{{- if .Values.targetProjectId }}
+      project_id {{ .Values.targetProjectId }}
+{{- end }}
+      # Try to detect JSON formatted log entries.
+      detect_json true
+      # Collect metrics in Prometheus registry about plugin activity.
+      enable_monitoring true
+      monitoring_type prometheus
+      # Allow log entries from multiple containers to be sent in the same request.
+      split_logs_by_tag false
+      # Set the buffer type to file to improve the reliability and reduce the memory consumption
+      buffer_type file
+
+      buffer_path /var/run/google-fluentd/buffers/kubernetes.containers.buffer
+
+      # Set queue_full action to block because we want to pause gracefully
+      # in case of the off-the-limits load instead of throwing an exception
+      buffer_queue_full_action block
+      # Set the chunk limit conservatively to avoid exceeding the recommended
+      # chunk size of 5MB per write request.
+      buffer_chunk_limit 512k
+      # Cap the combined memory usage of this buffer and the one below to
+      # 512KiB/chunk * (6 + 2) chunks = 4 MiB
+      buffer_queue_limit 6
+      # Never wait more than 5 seconds before flushing logs in the non-error case.
+      flush_interval 5s
+      # Never wait longer than 30 seconds between retries.
+      max_retry_wait 30
+      # Disable the limit on the number of retries (retry forever).
+      disable_retry_limit
+      # Use multiple threads for processing.
+      num_threads 2
+      use_grpc true
+      # Skip timestamp adjustment as this is in a controlled environment with
+      # known timestamp format. This helps with CPU usage.
+      adjust_invalid_timestamps false
+    </match>
+
+    # Attach local_resource_id for 'k8s_node' monitored resource.
+    <filter **>
+      @type record_transformer
+      enable_ruby true
+      <record>
+        "logging.googleapis.com/local_resource_id" ${"k8s_node.#{ENV['NODE_NAME']}"}
+      </record>
+    </filter>
+
+    # This section is exclusive for 'k8s_node' logs. These logs come with tags
+    # that are neither 'stderr' or 'stdout'.
+    # We use a separate output stanza for 'k8s_container' logs with a larger
+    # buffer because user's container logs are more important than node logs.
+    <match **>
+      @type google_cloud
+{{- if .Values.targetProjectId }}
+      project_id {{ .Values.targetProjectId }}
+{{- end }}
+      detect_json true
+      enable_monitoring true
+      monitoring_type prometheus
+      # Allow entries from multiple system logs to be sent in the same request.
+      split_logs_by_tag false
+      detect_subservice false
+      buffer_type file
+
+      buffer_path /var/run/google-fluentd/buffers/kubernetes.system.buffer
+
+      buffer_queue_full_action block
+      buffer_chunk_limit 512k
+      buffer_queue_limit 2
+      flush_interval 5s
+      max_retry_wait 30
+      disable_retry_limit
+      num_threads 2
+      use_grpc true
+      # Skip timestamp adjustment as this is in a controlled environment with
+      # known timestamp format. This helps with CPU usage.
+      adjust_invalid_timestamps false
+    </match>
+  system.input.conf: |-
+    # Example:
+    # Dec 21 23:17:22 gke-foo-1-1-4b5cbd14-node-4eoj startupscript: Finished running startup script /var/run/google.startup.script
+    <source>
+      @type tail
+      format syslog
+      path /var/log/startupscript.log
+
+      pos_file /var/run/google-fluentd/pos-files/gcp-startupscript.pos
+
+      tag startupscript
+    </source>
+
+    # Examples:
+    # time="2016-02-04T06:51:03.053580605Z" level=info msg="GET /containers/json"
+    # time="2016-02-04T07:53:57.505612354Z" level=error msg="HTTP Error" err="No such image: -f" statusCode=404
+    # TODO(random-liu): Remove this after cri container runtime rolls out.
+    <source>
+      @type tail
+      format /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
+      path /var/log/docker.log
+
+      pos_file /var/run/google-fluentd/pos-files/gcp-docker.pos
+
+      tag docker
+    </source>
+
+    # Example:
+    # 2016/02/04 06:52:38 filePurge: successfully removed file /var/etcd/data/member/wal/00000000000006d0-00000000010a23d1.wal
+    <source>
+      @type tail
+      # Not parsing this, because it doesn't have anything particularly useful to
+      # parse out of it (like severities).
+      format none
+      path /var/log/etcd.log
+
+      pos_file /var/run/google-fluentd/pos-files/gcp-etcd.pos
+
+      tag etcd
+    </source>
+
+    # Multi-line parsing is required for all the kube logs because very large log
+    # statements, such as those that include entire object bodies, get split into
+    # multiple lines by glog.
+
+    # Example:
+    # I0204 07:32:30.020537    3368 server.go:1048] POST /stats/container/: (13.972191ms) 200 [[Go-http-client/1.1] 10.244.1.3:40537]
+    <source>
+      @type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\w\d{4}/
+      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+      time_format %m%d %H:%M:%S.%N
+      path /var/log/kubelet.log
+
+      pos_file /var/run/google-fluentd/pos-files/gcp-kubelet.pos
+
+      tag kubelet
+    </source>
+
+    # Example:
+    # I1118 21:26:53.975789       6 proxier.go:1096] Port "nodePort for kube-system/default-http-backend:http" (:31429/tcp) was open before and is still needed
+    <source>
+      @type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\w\d{4}/
+      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+      time_format %m%d %H:%M:%S.%N
+      path /var/log/kube-proxy.log
+
+      pos_file /var/run/google-fluentd/pos-files/gcp-kube-proxy.pos
+
+      tag kube-proxy
+    </source>
+
+    # Example:
+    # I0204 07:00:19.604280       5 handlers.go:131] GET /api/v1/nodes: (1.624207ms) 200 [[kube-controller-manager/v1.1.3 (linux/amd64) kubernetes/6a81b50] 127.0.0.1:38266]
+    <source>
+      @type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\w\d{4}/
+      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+      time_format %m%d %H:%M:%S.%N
+      path /var/log/kube-apiserver.log
+
+      pos_file /var/run/google-fluentd/pos-files/gcp-kube-apiserver.pos
+
+      tag kube-apiserver
+    </source>
+
+    # Example:
+    # I0204 06:55:31.872680       5 servicecontroller.go:277] LB already exists and doesn't need update for service kube-system/kube-ui
+    <source>
+      @type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\w\d{4}/
+      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+      time_format %m%d %H:%M:%S.%N
+      path /var/log/kube-controller-manager.log
+
+      pos_file /var/run/google-fluentd/pos-files/gcp-kube-controller-manager.pos
+
+      tag kube-controller-manager
+    </source>
+
+    # Example:
+    # W0204 06:49:18.239674       7 reflector.go:245] pkg/scheduler/factory/factory.go:193: watch of *api.Service ended with: 401: The event in requested index is outdated and cleared (the requested history has been cleared [2578313/2577886]) [2579312]
+    <source>
+      @type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\w\d{4}/
+      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+      time_format %m%d %H:%M:%S.%N
+      path /var/log/kube-scheduler.log
+
+      pos_file /var/run/google-fluentd/pos-files/gcp-kube-scheduler.pos
+
+      tag kube-scheduler
+    </source>
+
+    # Example:
+    # I1104 10:36:20.242766       5 rescheduler.go:73] Running Rescheduler
+    <source>
+      @type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\w\d{4}/
+      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+      time_format %m%d %H:%M:%S.%N
+      path /var/log/rescheduler.log
+
+      pos_file /var/run/google-fluentd/pos-files/gcp-rescheduler.pos
+
+      tag rescheduler
+    </source>
+
+    # Example:
+    # I0603 15:31:05.793605       6 cluster_manager.go:230] Reading config from path /etc/gce.conf
+    <source>
+      @type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\w\d{4}/
+      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+      time_format %m%d %H:%M:%S.%N
+      path /var/log/glbc.log
+
+      pos_file /var/run/google-fluentd/pos-files/gcp-glbc.pos
+
+      tag glbc
+    </source>
+
+    # Example:
+    # I0603 15:31:05.793605       6 cluster_manager.go:230] Reading config from path /etc/gce.conf
+    <source>
+      @type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\w\d{4}/
+      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+      time_format %m%d %H:%M:%S.%N
+      path /var/log/cluster-autoscaler.log
+
+      pos_file /var/run/google-fluentd/pos-files/gcp-cluster-autoscaler.pos
+
+      tag cluster-autoscaler
+    </source>
+
+    # Logs from systemd-journal for interesting services.
+    # TODO(random-liu): Keep this for compatibility, remove this after
+    # cri container runtime rolls out.
+    <source>
+      @type systemd
+      filters [{ "_SYSTEMD_UNIT": "docker.service" }]
+
+      <storage>
+        @type local
+        path /var/run/google-fluentd/pos-files/gcp-journald-docker.pos
+      </storage>
+
+      read_from_head true
+      tag docker
+    </source>
+
+    <source>
+      @type systemd
+      filters [{ "_SYSTEMD_UNIT": "docker.service" }]
+
+      <storage>
+        @type local
+        path /var/run/google-fluentd/pos-files/gcp-journald-container-runtime.pos
+      </storage>
+
+      read_from_head true
+      tag container-runtime
+    </source>
+
+    <source>
+      @type systemd
+      filters [{ "_SYSTEMD_UNIT": "kubelet.service" }]
+
+      <storage>
+        @type local
+        path /var/run/google-fluentd/pos-files/gcp-journald-kubelet.pos
+      </storage>
+
+      read_from_head true
+      tag kubelet
+    </source>
+
+    <source>
+      @type systemd
+      filters [{ "_SYSTEMD_UNIT": "node-problem-detector.service" }]
+      pos_file /var/log/gcp-journald-node-problem-detector.pos
+      read_from_head true
+      tag node-problem-detector
+    </source>
+
+
+    <source>
+      @type systemd
+      filters [{ "_SYSTEMD_UNIT": "kube-container-runtime-monitor.service" }]
+      pos_file /var/log/gcp-journald-kube-container-runtime-monitor.pos
+      read_from_head true
+      tag kube-container-runtime-monitor
+    </source>
+
+    <source>
+      @type systemd
+      filters [{ "_SYSTEMD_UNIT": "kubelet-monitor.service" }]
+      pos_file /var/log/gcp-journald-kubelet-monitor.pos
+      read_from_head true
+      tag kubelet-monitor
+    </source>

--- a/jx-app-sd-exporter/templates/fluentd-gcp-daemonset.yaml
+++ b/jx-app-sd-exporter/templates/fluentd-gcp-daemonset.yaml
@@ -1,0 +1,137 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  selector:
+    matchLabels:
+      chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      containers:
+      - name: fluentd-gcp
+        image: "{{ .Values.fluentd.image.repository }}:{{ .Values.fluentd.image.tag }}"
+        imagePullPolicy: "{{ .Values.fluentd.image.pullPolicy }}"
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: STACKDRIVER_METADATA_AGENT_URL
+          value: http://$(NODE_NAME):8799
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - |2
+
+              LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300}; STUCK_THRESHOLD_SECONDS=${STUCK_THRESHOLD_SECONDS:-900}; if [ ! -e /var/run/google-fluentd/buffers ]; then
+                exit 1;
+              fi; touch -d "${STUCK_THRESHOLD_SECONDS} seconds ago" /tmp/marker-stuck; if [ -z "$(find /var/run/google-fluentd/buffers -type d -newer /tmp/marker-stuck -print -quit)" ]; then
+                rm -rf /var/run/google-fluentd/buffers;
+                exit 1;
+              fi; touch -d "${LIVENESS_THRESHOLD_SECONDS} seconds ago" /tmp/marker-liveness; if [ -z "$(find /var/run/google-fluentd/buffers -type d -newer /tmp/marker-liveness -print -quit)" ]; then
+                exit 1;
+              fi;
+          failureThreshold: 3
+          initialDelaySeconds: 600
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: "{{ .Values.fluentd.resources.limits.cpu }}"
+            memory: "{{ .Values.fluentd.resources.limits.memory }}"
+          requests:
+            cpu: "{{ .Values.fluentd.resources.requests.cpu }}"
+            memory: "{{ .Values.fluentd.resources.requests.memory }}"
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/run/google-fluentd
+          name: varrun
+        - mountPath: /var/log
+          name: varlog
+        - mountPath: /var/lib/docker/containers
+          name: varlibdockercontainers
+          readOnly: true
+        - mountPath: /etc/google-fluentd/config.d
+          name: config-volume
+      - name: prometheus-to-sd-exporter
+        image: "{{ .Values.prometheusToStackdriver.image.repository }}:{{ .Values.prometheusToStackdriver.image.tag }}"
+        imagePullPolicy: "{{ .Values.prometheusToStackdriver.image.pullPolicy }}"
+        command:
+        - /monitor
+        - --stackdriver-prefix={{ .Values.prometheusToStackdriver.stackdriverMetricsPrefix }}
+        - --api-override=https://monitoring.googleapis.com/
+        - --source=fluentd:http://localhost:24231?whitelisted=stackdriver_successful_requests_count,stackdriver_failed_requests_count,stackdriver_ingested_entries_count,stackdriver_dropped_entries_count
+        - --pod-id=$(POD_NAME)
+        - --namespace-id=$(POD_NAMESPACE)
+{{- if .Values.targetProjectId }}
+        - --project-id={{ .Values.targetProjectId }}
+{{- end }}
+{{- if .Values.cluster.zone }}
+        - --zone-override={{ .Values.cluster.zone }}
+{{- end }}
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: Default
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: fluentd-gcp
+      serviceAccountName: fluentd-gcp
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /var/run/google-fluentd
+          type: ""
+        name: varrun
+      - hostPath:
+          path: /var/log
+          type: ""
+        name: varlog
+      - hostPath:
+          path: /var/lib/docker/containers
+          type: ""
+        name: varlibdockercontainers
+      - configMap:
+          defaultMode: 420
+          name: fluentd-gcp-config
+        name: config-volume

--- a/jx-app-sd-exporter/templates/fluentd-gcp-sa.yaml
+++ b/jx-app-sd-exporter/templates/fluentd-gcp-sa.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+  name: fluentd-gcp
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fluentd-gcp
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  verbs:
+  - watch
+  - get
+  - list
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fluentd-gcp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fluentd-gcp
+subjects:
+- kind: ServiceAccount
+  name: fluentd-gcp

--- a/jx-app-sd-exporter/templates/prometheus-to-sd-configmap.yaml
+++ b/jx-app-sd-exporter/templates/prometheus-to-sd-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: networking-metrics-config
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+data:
+  export_interval: 2m
+  metrics_address: localhost:10231
+  metrics_collectors: conntrack,socket

--- a/jx-app-sd-exporter/templates/prometheus-to-sd-daemonset.yaml
+++ b/jx-app-sd-exporter/templates/prometheus-to-sd-daemonset.yaml
@@ -1,0 +1,76 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: prometheus-to-sd
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  selector:
+    matchLabels:
+      chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+  template:
+    metadata:
+      labels:
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      containers:
+      - name: prometheus-to-sd
+        image: "{{ .Values.prometheusToStackdriver.image.repository }}:{{ .Values.prometheusToStackdriver.image.tag }}"
+        imagePullPolicy: "{{ .Values.prometheusToStackdriver.image.pullPolicy }}"
+        command:
+        - /monitor
+        - --source=node:http://$(METRICS_ADDRESS)?whitelisted=conntrack_entries,conntrack_error_count,num_inuse_sockets,num_tw_sockets,socket_memory&metricsPrefix=kubernetes.io/internal/net/cluster
+        - --source=kube-proxy:http://localhost:10249?whitelisted=sync_proxy_rules_latency_microseconds&metricsPrefix=kubernetes.io/internal/addons
+        - --source=kubelet:http://localhost:10255?whitelisted=docker_operations,docker_operations_errors,runtime_operations,runtime_operations_errors,runtime_operations_latency_microseconds,pleg_relist_latency_microseconds,pod_start_latency_microseconds,rest_client_requests_total,storage_operation_duration_seconds,storage_operation_errors_total,run_podsandbox_duration_seconds,run_podsandbox_errors_total,storage_operation_status_count
+        - --source=kubelet:http://localhost:10255/metrics/probes?whitelisted=prober_probe_total&podIdLabel=pod&namespaceIdLabel=namespace&containerNameLabel=container
+        - --api-override=https://monitoring.googleapis.com/
+        - --monitored-resource-type-prefix=k8s_
+        - --node-name=$(NODE_NAME)
+        - --stackdriver-prefix={{ .Values.prometheusToStackdriver.stackdriverMetricsPrefix }}
+        - --monitored-resource-labels=location={{ .Values.cluster.location }}
+        - --export-interval={{ .Values.prometheusToStackdriver.exportInterval }}
+{{- if .Values.targetProjectId }}
+        - --project-id={{ .Values.targetProjectId }}
+{{- end }}
+{{- if .Values.cluster.zone }}
+        - --zone-override={{ .Values.cluster.zone }}
+{{- end }}
+{{- if .Values.cluster.name }}
+        - --cluster-name={{ .Values.cluster.name }}
+{{- end }}
+{{- if .Values.cluster.location }}
+        - --cluster-location={{ .Values.cluster.location }}
+{{- end }}
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: METRICS_ADDRESS
+          valueFrom:
+            configMapKeyRef:
+              key: metrics_address
+              name: networking-metrics-config
+        resources:
+          limits:
+            cpu: "{{ .Values.prometheusToStackdriver.resources.limits.cpu }}"
+            memory: "{{ .Values.prometheusToStackdriver.resources.limits.memory }}"
+          requests:
+            cpu: "{{ .Values.prometheusToStackdriver.resources.requests.cpu }}"
+            memory: "{{ .Values.prometheusToStackdriver.resources.requests.memory }}"
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: prometheus-to-sd
+      serviceAccountName: prometheus-to-sd
+      terminationGracePeriodSeconds: 30
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate

--- a/jx-app-sd-exporter/templates/prometheus-to-sd-sa.yaml
+++ b/jx-app-sd-exporter/templates/prometheus-to-sd-sa.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-to-sd
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/jx-app-sd-exporter/values.yaml
+++ b/jx-app-sd-exporter/values.yaml
@@ -1,0 +1,31 @@
+targetProjectId:
+cluster:
+  name:
+  zone:
+  location:
+fluentd:
+  image:
+    repository: gcr.io/stackdriver-agents/stackdriver-logging-agent
+    tag: 1.6.17-16060
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: "1"
+      memory: 500Mi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+prometheusToStackdriver:
+  stackdriverMetricsPrefix: "custom.googleapis.com"
+  exportInterval: 120s
+  image:
+    repository: k8s.gcr.io/prometheus-to-sd
+    tag: v0.8.2
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 3m
+      memory: 20Mi
+    requests:
+      cpu: 1m
+      memory: 20Mi


### PR DESCRIPTION
First version of a JX app exporting GKE cluster logs and metrics to a different project than the current one.
The goal is to centralize logs/metrics of multiple cluster into a central project.

Pre-requisites: the GCP Service Account used by GKE nodes of the project where the GKE cluster is hosted needs to have logs/metrics write permissions to the target cluster.

See https://github.com/cloudbees/arcalos/issues/501